### PR TITLE
Update NewBitdefenderCompany.ps1 - fix invalid default license varaia…

### DIFF
--- a/PSBitdefenderAPI/Companies/NewBitdefenderCompany.ps1
+++ b/PSBitdefenderAPI/Companies/NewBitdefenderCompany.ps1
@@ -41,10 +41,10 @@ function NewBitdefenderCompany {
         [int]$LicenseReservedSlots = $null,
 
         [Parameter(Mandatory=$False)]
-        [bool]$LicenseExchange = $null,
+        [bool]$LicenseExchange = $false,
 
         [Parameter(Mandatory=$False)]
-        [bool]$LicenseEncryption = $null
+        [bool]$LicenseEncryption = $false
     )
 
     $Options = @{}


### PR DESCRIPTION
…ble values

API no longer accepts $null as valid for $LicenseExchange and $LicenseEncryption variables, changed to $false